### PR TITLE
Add QTH profile

### DIFF
--- a/src/app/pages/logbook/logbook.component.ts
+++ b/src/app/pages/logbook/logbook.component.ts
@@ -52,7 +52,7 @@ export class LogbookComponent implements OnInit {
 
   logbookSettings(): void {
     const dialogRef = this.dialog.open(LogbookSettingsComponent, {
-      width: '500px',
+      width: '800px',
     });
     dialogRef.afterClosed().subscribe((dialogReturn) => {
       if (dialogReturn instanceof Observable) {

--- a/src/app/pages/logbook/logbook.service.ts
+++ b/src/app/pages/logbook/logbook.service.ts
@@ -1,21 +1,45 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, from, Observable } from 'rxjs';
+import { BehaviorSubject, from, Observable, of } from 'rxjs';
 import { AngularFirestore } from '@angular/fire/compat/firestore';
 import { AuthService } from '../../shared/auth/auth.service';
-import { mergeMap } from 'rxjs/operators';
+import { mergeMap, switchMap } from 'rxjs/operators';
 import { UserSettingsService } from '../../shared/user-settings/user-settings.service';
+import { Station } from '../../qso';
 
 @Injectable({
   providedIn: 'root',
 })
 export class LogbookService {
   logbookId$ = new BehaviorSubject<string>(null);
+  settings$ = new BehaviorSubject<LogbookSettings>({} as LogbookSettings);
+  started = false;
 
   constructor(
     private authService: AuthService,
     private firestore: AngularFirestore,
     private userSettingsService: UserSettingsService
   ) {}
+
+  public init(): void {
+    if (this.started === true) {
+      return;
+    }
+    this.started = true;
+    this.logbookId$
+      .pipe(
+        switchMap((logbookId) => {
+          if (logbookId == null) {
+            return of({});
+          }
+          return this.firestore
+            .doc<LogbookSettings>('logbooks/' + logbookId)
+            .valueChanges();
+        })
+      )
+      .subscribe((settings) => {
+        this.settings$.next(settings as LogbookSettings);
+      });
+  }
 
   public createLogbook(callsign: string): Observable<void> {
     const user = this.authService.user$.getValue();
@@ -39,4 +63,27 @@ export class LogbookService {
       )
     );
   }
+
+  public settings(): Observable<LogbookSettings> {
+    return this.settings$;
+  }
+
+  set(values: LogbookSettings): Observable<void> {
+    return this.logbookId$.pipe(
+      switchMap((logbookId) => {
+        if (logbookId == null) {
+          return of(null);
+        }
+        return this.firestore
+          .doc<LogbookSettings>('logbooks/' + logbookId)
+          .update(values);
+      })
+    );
+  }
+}
+
+export interface LogbookSettings {
+  lotwLastFetchedDate: Date;
+  qrzLogbookApiKeyLastSet: Date;
+  qthProfile: Station;
 }

--- a/src/app/pages/qso-list/qso-list.component.ts
+++ b/src/app/pages/qso-list/qso-list.component.ts
@@ -56,6 +56,7 @@ export class QsoListComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.logbookService.init();
     this.logbookService.logbookId$.subscribe((id) => this.qsoService.init(id));
     this.paginator.pageSize = 25;
     this.paginator.pageSizeOptions = [10, 25, 50, 100];
@@ -151,7 +152,10 @@ export class QsoListComponent implements OnInit {
   }
 
   newQso(): void {
-    this.openDialog({ qso: { contactedStation: {}, loggingStation: {} } });
+    const loggingStation = this.logbookService.settings$.getValue().qthProfile;
+    this.openDialog({
+      qso: { contactedStation: {}, loggingStation: loggingStation },
+    });
   }
 
   flagFor(dxcc: number): string {

--- a/src/app/shared/agent/agent.component.ts
+++ b/src/app/shared/agent/agent.component.ts
@@ -6,6 +6,7 @@ import {
 } from 'ngx-kel-agent';
 import { Band } from '../../reference/band';
 import { Component, OnInit } from '@angular/core';
+import { LogbookService } from '../../pages/logbook/logbook.service';
 import { Qso } from '../../qso';
 import { QsoService } from '../qso/qso.service';
 
@@ -19,11 +20,13 @@ export class AgentComponent implements OnInit {
     public agent: AgentService,
     public hamlib: HamlibService,
     public wsjtx: WsjtxService,
+    private logbookService: LogbookService,
     private qsoService: QsoService
   ) {}
 
   ngOnInit(): void {
     this.agent.init();
+    this.logbookService.init();
     // When WSJT-X sends a QSO, log it right away
     this.wsjtx.qsoLogged$.subscribe((qsoLogged) => {
       // Dates come across as strings; convert to objects
@@ -39,6 +42,7 @@ export class AgentComponent implements OnInit {
 
   private saveWsjtxQso(qsoLogged: WsjtxQsoLogged): void {
     // TODO: do something with "exchange sent/received"; contest fields?
+    const qthProfile = this.logbookService.settings$.getValue().qthProfile;
     const freqMhz = qsoLogged.txFrequency / 1000000;
     const qso: Qso = {
       band: Band.freqToBand(freqMhz),
@@ -52,6 +56,7 @@ export class AgentComponent implements OnInit {
         opName: qsoLogged.name,
       },
       loggingStation: {
+        ...qthProfile,
         stationCall: qsoLogged.myCall,
         gridSquare: qsoLogged.myGrid,
         power: Number(qsoLogged.txPower),

--- a/src/app/shared/logbook-settings/logbook-settings.component.html
+++ b/src/app/shared/logbook-settings/logbook-settings.component.html
@@ -1,29 +1,51 @@
 <h2 mat-dialog-title>Logbook Settings</h2>
 <mat-dialog-content>
-  These values are stored encrypted on the server and will not be displayed
-  here.
-  <form [formGroup]="logbookSettingsForm">
-    <div>
-      <mat-form-field appearance="standard">
-        <mat-label>QRZ.com Logbook API Key</mat-label>
-        <input
-          matInput
-          placeholder="ABCD-1234-EFGH-5678"
-          formControlName="qrzLogbookApiKey"
-        />
-      </mat-form-field>
-    </div>
-    <div fxLayout="row" class="row">
-      <mat-form-field fxFlex appearance="standard">
-        <mat-label>LotW Username</mat-label>
-        <input matInput formControlName="lotwUser" />
-      </mat-form-field>
-      <mat-form-field fxFlex appearance="standard">
-        <mat-label>LotW Password</mat-label>
-        <input matInput type="password" formControlName="lotwPass" />
-      </mat-form-field>
-    </div>
-  </form>
+  <mat-card>
+    <mat-card-subtitle>QTH Profile</mat-card-subtitle>
+    <mat-card-content>
+      <kel-station-detail
+        [(station)]="qthProfile"
+        (stationChange)="enableSaveButton()"
+        [showTxPower]="false"
+      ></kel-station-detail>
+    </mat-card-content>
+  </mat-card>
+  <mat-card>
+    <mat-card-subtitle>Secrets</mat-card-subtitle>
+    <mat-card-content>
+      <form [formGroup]="logbookSettingsForm">
+        <div fxLayout="row" class="row">
+          These values are stored encrypted on the server and will not be
+          displayed here.
+        </div>
+        <div fxLayout="row" class="row">
+          <mat-form-field appearance="standard">
+            <mat-label>QRZ.com Logbook API Key</mat-label>
+            <input
+              matInput
+              placeholder="ABCD-1234-EFGH-5678"
+              formControlName="qrzLogbookApiKey"
+            />
+            <mat-hint>For syncing with a QRZ.com logbook</mat-hint>
+          </mat-form-field>
+        </div>
+        <div fxLayout="row" class="row">
+          <mat-form-field fxFlex appearance="standard">
+            <mat-label>LotW Username</mat-label>
+            <input matInput formControlName="lotwUser" />
+            <mat-hint>
+              For querying station details from the QRZ.com database
+            </mat-hint>
+          </mat-form-field>
+          <mat-form-field fxFlex appearance="standard">
+            <mat-label>LotW Password</mat-label>
+            <input matInput type="password" formControlName="lotwPass" />
+            <mat-hint> Requires QRZ.com XML subscription </mat-hint>
+          </mat-form-field>
+        </div>
+      </form>
+    </mat-card-content>
+  </mat-card>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">

--- a/src/app/shared/logbook-settings/logbook-settings.component.scss
+++ b/src/app/shared/logbook-settings/logbook-settings.component.scss
@@ -13,6 +13,16 @@
   width: 100%;
 }
 
+:host ::ng-deep .mat-form-field-infix {
+  width: auto !important;
+}
+
 mat-form-field.ng-dirty {
   color: mat.get-color-from-palette($kel-accent, 800);
+}
+
+mat-card {
+  border: 1px solid mat.get-color-from-palette($kel-primary, A100);
+  margin-bottom: 8px;
+  margin-top: 8px;
 }

--- a/src/app/shared/logbook-settings/logbook-settings.component.ts
+++ b/src/app/shared/logbook-settings/logbook-settings.component.ts
@@ -4,7 +4,10 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
 import { MatDialogRef } from '@angular/material/dialog';
 import { SecretService } from '../secret/secret.service';
-import { LogbookService } from '../../pages/logbook/logbook.service';
+import {
+  LogbookService,
+  LogbookSettings,
+} from '../../pages/logbook/logbook.service';
 import { Station } from '../../qso';
 
 @Component({
@@ -15,7 +18,7 @@ import { Station } from '../../qso';
 export class LogbookSettingsComponent implements OnInit {
   logbookSettingsForm: FormGroup;
   @ViewChild('saveButton') saveButton: MatButton;
-  qthProfile: Station = {};
+  qthProfile = {} as Station;
 
   constructor(
     private dialog: MatDialogRef<any>,
@@ -33,13 +36,22 @@ export class LogbookSettingsComponent implements OnInit {
     );
   }
 
+  ngOnInit(): void {
+    this.logbookService.init();
+    this.logbookService.settings$.subscribe((settings) => {
+      this.qthProfile = settings.qthProfile;
+    });
+  }
+
   enableSaveButton(): void {
     this.saveButton.disabled = false;
   }
 
-  ngOnInit(): void {}
-
   save(): void {
+    const qthObs = this.logbookService.set({
+      qthProfile: this.qthProfile,
+    } as LogbookSettings);
+
     const formValue = this.logbookSettingsForm.value;
     const secretsObs = this.secretService.setSecrets(
       new Map([
@@ -49,6 +61,7 @@ export class LogbookSettingsComponent implements OnInit {
       ]),
       this.logbookService.logbookId$.getValue()
     );
-    this.dialog.close(forkJoin([secretsObs]));
+
+    this.dialog.close(forkJoin([qthObs, secretsObs]));
   }
 }

--- a/src/app/shared/logbook-settings/logbook-settings.component.ts
+++ b/src/app/shared/logbook-settings/logbook-settings.component.ts
@@ -5,6 +5,7 @@ import { MatButton } from '@angular/material/button';
 import { MatDialogRef } from '@angular/material/dialog';
 import { SecretService } from '../secret/secret.service';
 import { LogbookService } from '../../pages/logbook/logbook.service';
+import { Station } from '../../qso';
 
 @Component({
   selector: 'kel-logbook-settings',
@@ -14,6 +15,7 @@ import { LogbookService } from '../../pages/logbook/logbook.service';
 export class LogbookSettingsComponent implements OnInit {
   logbookSettingsForm: FormGroup;
   @ViewChild('saveButton') saveButton: MatButton;
+  qthProfile: Station = {};
 
   constructor(
     private dialog: MatDialogRef<any>,
@@ -26,9 +28,13 @@ export class LogbookSettingsComponent implements OnInit {
       lotwUser: '',
       lotwPass: '',
     });
-    this.logbookSettingsForm.valueChanges.subscribe(
-      () => (this.saveButton.disabled = false)
+    this.logbookSettingsForm.valueChanges.subscribe(() =>
+      this.enableSaveButton()
     );
+  }
+
+  enableSaveButton(): void {
+    this.saveButton.disabled = false;
   }
 
   ngOnInit(): void {}

--- a/src/app/shared/station-detail/station-detail.component.ts
+++ b/src/app/shared/station-detail/station-detail.component.ts
@@ -60,12 +60,6 @@ export class StationDetailComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (!changes.station.firstChange) {
-      return;
-    }
-    // Ideally this would be part of ngOnInit, but it seems like the parent
-    // (QsoDetailComponent) is not initializing the bound variables until after
-    // this is init, so instead, init this stuff on the first change.
     this.station = changes.station.currentValue;
     const model: Station = {
       ...this.template,


### PR DESCRIPTION
Adds a QTH profile entry in logbook settings, and uses them when adding a new QSO either through manual entry or WSJT-X import.

Resolves #131