### PR TITLE
Fix ignoreUndefinedProperties

### DIFF
--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -1,8 +1,8 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { initializeApp, provideFirebaseApp } from '@angular/fire/app';
+import { getApp, initializeApp, provideFirebaseApp } from '@angular/fire/app';
 import { getAuth, provideAuth } from '@angular/fire/auth';
-import { getFirestore, provideFirestore } from '@angular/fire/firestore';
+import { initializeFirestore, provideFirestore } from '@angular/fire/firestore';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { GoogleMapsModule } from '@angular/google-maps';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
@@ -81,7 +81,9 @@ import { UserSettingsService } from './shared/user-settings/user-settings.servic
   imports: [
     provideAuth(() => getAuth()),
     provideFirebaseApp(() => initializeApp(environment.firebase)),
-    provideFirestore(() => getFirestore()),
+    provideFirestore(() =>
+      initializeFirestore(getApp(), { ignoreUndefinedProperties: true }),
+    ),
     AppRoutingModule,
     BrowserAnimationsModule,
     BrowserModule,


### PR DESCRIPTION
This used to be set before #2164, and its absence is causing updates to QSOs to fail (probably among other things).