### PR TITLE
Recent session map

### DIFF
--- a/web/src/app/pages/map/map.component.html
+++ b/web/src/app/pages/map/map.component.html
@@ -1,6 +1,6 @@
 <mat-card appearance="outlined">
   <mat-card-header>
-    <mat-card-title>Last 24 Hours</mat-card-title>
+    <mat-card-title>Most Recent Session</mat-card-title>
   </mat-card-header>
   <mat-card-content>
     <google-map


### PR DESCRIPTION
Instead of showing the past 24 hours, show a 24-hour window ending with the most recent QSO. That way, the map always has something interesting to show.

Also fix a long-standing bug that would cause the time window filter to be lost and make every QSO in the logbook show on the map.